### PR TITLE
Add EntityTypesSubset generic type

### DIFF
--- a/templates/typings.js
+++ b/templates/typings.js
@@ -17,6 +17,8 @@ export class EntityTypes {
     }
 }
 
+export type EntityTypesSubset<T extends keyof typeof EntityTypes> = keyof Pick<typeof EntityTypes, T>;
+
 // Interfaces
 export type Scalar = number | string | string[] | Date;
 export type Strings = string | string[];


### PR DESCRIPTION
`EntityTypesSubset` allows users to create string literal unions from property names in `EntityTypes`.

This exists in Novo, but it'd be great to have it come from bullhorn-types instead so that novo-elements can use it, too.

Here's a typescript playground with an example usage: http://www.typescriptlang.org/play/index.html#src=class%20EightiesActionStars%20%7B%20%2F%2F%20aka%20%22EntityTypes%22%0D%0A%20%20%20%20static%20SylvesterStallone%3A%20string%3B%0D%0A%20%20%20%20static%20WesleySnipes%3A%20string%3B%0D%0A%20%20%20%20static%20DolphLundgren%3A%20string%3B%0D%0A%20%20%20%20static%20ChuckNorris%3A%20string%3B%0D%0A%20%20%20%20static%20StevenSeagal%3A%20string%3B%0D%0A%20%20%20%20static%20ArnoldSchwarzenegger%3A%20string%3B%0D%0A%7D%0D%0A%0D%0Atype%20EntityTypesSubset%3CT%20extends%20keyof%20typeof%20EightiesActionStars%3E%20%3D%20keyof%20Pick%3Ctypeof%20EightiesActionStars%2C%20T%3E%3B%0D%0A%0D%0Atype%20WasInExpendables3%20%2F*%20aka%20'FastFindEntityTypes'%20*%2F%20%3D%20EntityTypesSubset%3C'ArnoldSchwarzenegger'%20%7C%20'SylvesterStallone'%20%7C%20'DolphLundgren'%20%7C%20'WesleySnipes'%3E%3B%0D%0A%0D%0Aconst%20bestExpendablesActors%3A%20WasInExpendables3%5B%5D%20%3D%20%5B'ArnoldSchwarzenegger'%2C%20'DolphLundgren'%5D%3B%0D%0A%0D%0Aconst%20linesForEachActor%3A%20Record%3CWasInExpendables3%2C%20string%5B%5D%3E%20%3D%20%7B%0D%0A%20%20%20%20ArnoldSchwarzenegger%3A%20%5B%5D%2C%0D%0A%20%20%20%20SylvesterStallone%3A%20%5B%5D%2C%0D%0A%20%20%20%20DolphLundgren%3A%20%5B%5D%2C%0D%0A%20%20%20%20WesleySnipes%3A%20%5B%5D%0D%0A%7D